### PR TITLE
Documentation updates+corrections

### DIFF
--- a/LexAPI.lua
+++ b/LexAPI.lua
@@ -9,7 +9,7 @@ following options:
     RobloxPlayerBeta --API api.txt
 
 These dump the API to a file named `api.txt`. Note that Studio does not 
-currently support this paramater. However, the ReflectionMetadata.xml file is 
+currently support this command. However, the ReflectionMetadata.xml file is 
 required to generate the dump (otherwise a parsing error is reported), but is 
 currently only distributed with studio and needs to be copied to 
 RobloxPlayerBeta.exe's folder.

--- a/ParseAPI.lua
+++ b/ParseAPI.lua
@@ -9,7 +9,7 @@ following options:
     RobloxPlayerBeta --API api.txt
 
 These dump the API to a file named `api.txt`. Note that Studio does not 
-currently support this paramater. However, the ReflectionMetadata.xml file is 
+currently support this command. However, the ReflectionMetadata.xml file is 
 required to generate the dump (otherwise a parsing error is reported), but is 
 currently only distributed with studio and needs to be copied to 
 RobloxPlayerBeta.exe's folder.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ following options:
     RobloxPlayerBeta --API api.txt
 
 These dump the API to a file named `api.txt`. Note that Studio does not 
-currently support this paramater. However, the ReflectionMetadata.xml file is 
+currently support this command. However, the ReflectionMetadata.xml file is 
 required to generate the dump (otherwise a parsing error is reported), but is 
 currently only distributed with studio and needs to be copied to 
 RobloxPlayerBeta.exe's folder.


### PR DESCRIPTION
Two small things:

*Added a note about how `ReflectionMetadata.xml` is needed but currently only shipped with studio, and that studio does not support `--API`
*Fixed the format of tags in the example's output
